### PR TITLE
Partial Revert of Tokio to asycn-std for WASM support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@ target/
 **/*.rs.bk
 Cargo.lock
 .DS_Store
-.idea/

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -14,8 +14,7 @@ homepage = "https://github.com/nannou-org/nannou"
 edition = "2018"
 
 [dev-dependencies]
-tokio = { version = "1", features = ["full"] }
-futures = "0.3"
+async-std = "1.10.0"
 audrey = "0.3"
 hotglsl = { git = "https://github.com/nannou-org/hotglsl", branch = "master" }
 hrtf = "0.2"

--- a/examples/wgpu/wgpu_compute_shader/wgpu_compute_shader.rs
+++ b/examples/wgpu/wgpu_compute_shader/wgpu_compute_shader.rs
@@ -174,7 +174,7 @@ fn update(app: &App, model: &mut Model, _update: Update) {
             }
         }
     };
-    tokio::spawn(future);
+    async_std::task::spawn(future);
 
     // Check for resource cleanups and mapping callbacks.
     //

--- a/nannou/Cargo.toml
+++ b/nannou/Cargo.toml
@@ -11,8 +11,7 @@ homepage = "https://github.com/nannou-org/nannou"
 edition = "2018"
 
 [dependencies]
-tokio = { version = "1", features = ["full"] }
-futures = "0.3"
+async-std = "1.10.0"
 find_folder = "0.3"
 getrandom = "0.2.3"
 image = "0.23"
@@ -40,4 +39,4 @@ default = ["notosans"]
 # Enables SPIR-V support in the `wgpu` module.
 spirv = ["nannou_wgpu/spirv"]
 # Enables experimental WASM compilation for CI-use only
-wasm-experimental = ["getrandom/js", "web-sys", "wgpu_upstream/webgl"]
+wasm-experimental = ["getrandom/js", "web-sys", "wgpu_upstream/webgl", "async-std/unstable"]

--- a/nannou/src/app.rs
+++ b/nannou/src/app.rs
@@ -452,11 +452,7 @@ where
     /// thread as some platforms require that their application event loop and windows are
     /// initialised on the main thread.
     pub fn run(self) {
-        let rt = tokio::runtime::Builder::new_multi_thread()
-            .enable_all()
-            .build()
-            .expect("failed to create tokio runtime");
-        rt.block_on(self.run_async())
+        async_std::task::block_on(self.run_async())
     }
 
     pub async fn run_async(self) {

--- a/nannou/src/window.rs
+++ b/nannou/src/window.rs
@@ -734,11 +734,7 @@ impl<'app> Builder<'app> {
     #[cfg(not(target_os = "unknown"))]
     /// Builds the window, inserts it into the `App`'s display map and returns the unique ID.
     pub fn build(self) -> Result<Id, BuildError> {
-        tokio::task::block_in_place(move || {
-            tokio::runtime::Handle::current().block_on(async move {
-                self.build_async().await
-            })
-        })
+        async_std::task::block_on(self.build_async())
     }
 
     pub async fn build_async(self) -> Result<Id, BuildError> {

--- a/nannou_wgpu/Cargo.toml
+++ b/nannou_wgpu/Cargo.toml
@@ -10,8 +10,7 @@ homepage = "https://nannou.cc"
 edition = "2018"
 
 [dependencies]
-tokio = { version = "1", features = ["full"] }
-futures = "0.3"
+async-std = "1.10.0"
 image = { version = "0.23", optional = true }
 instant = { version = "0.1.9", optional = true }
 num_cpus = { version = "1", optional = true }

--- a/nannou_wgpu/src/device_map.rs
+++ b/nannou_wgpu/src/device_map.rs
@@ -75,8 +75,7 @@ impl AdapterMap {
         options: wgpu::RequestAdapterOptions<'b>,
         instance: &'a wgpu::Instance,
     ) -> Option<Arc<ActiveAdapter>> {
-        let rt = tokio::runtime::Handle::current();
-        rt.block_on(self.get_or_request_async(options, instance))
+        async_std::task::block_on(self.get_or_request_async(options, instance))
     }
 
     #[cfg(not(target_os = "unknown"))]
@@ -92,8 +91,7 @@ impl AdapterMap {
         options: wgpu::RequestAdapterOptions<'b>,
         instance: &'a wgpu::Instance,
     ) -> Option<Arc<ActiveAdapter>> {
-        let rt = tokio::runtime::Handle::current();
-        rt.block_on(self.request_async(options, instance))
+        async_std::task::block_on(self.request_async(options, instance))
     }
 
     /// The async implementation of `get_or_request`.
@@ -180,8 +178,7 @@ impl ActiveAdapter {
         &self,
         descriptor: wgpu::DeviceDescriptor<'static>,
     ) -> Arc<DeviceQueuePair> {
-        let rt = tokio::runtime::Handle::current();
-        rt.block_on(self.get_or_request_device_async(descriptor))
+        async_std::task::block_on(self.get_or_request_device_async(descriptor))
     }
 
     #[cfg(not(target_os = "unknown"))]
@@ -194,8 +191,7 @@ impl ActiveAdapter {
         &self,
         descriptor: wgpu::DeviceDescriptor<'static>,
     ) -> Arc<DeviceQueuePair> {
-        let rt = tokio::runtime::Handle::current();
-        rt.block_on(self.request_device_async(descriptor))
+        async_std::task::block_on(self.request_device_async(descriptor))
     }
 
     /// Check for a device with the given descriptor or request one.

--- a/nannou_wgpu/src/texture/capturer.rs
+++ b/nannou_wgpu/src/texture/capturer.rs
@@ -91,7 +91,11 @@ impl ThreadPool {
             active_futures.fetch_sub(1, atomic::Ordering::SeqCst);
         };
 
-        tokio::spawn(future);
+        #[cfg(not(target_os = "unknown"))]
+        async_std::task::spawn(future);
+        #[cfg(target_os = "unknown")]
+        async_std::task::spawn_local(future);
+
         Ok(())
     }
 

--- a/nannou_wgpu/src/texture/image.rs
+++ b/nannou_wgpu/src/texture/image.rs
@@ -312,6 +312,9 @@ impl wgpu::RowPaddedBuffer {
     /// polled. You should *not* rely on the being ready immediately.
     pub async fn read<'b>(&'b self) -> Result<ImageReadMapping<'b>, wgpu::BufferAsyncError> {
         let slice = self.buffer.slice(..);
+        slice.map_async(wgpu::MapMode::Read).await?;
+
+
         let (tx, rx) = futures::channel::oneshot::channel();
 
         slice.map_async(wgpu::MapMode::Read, |res| {


### PR DESCRIPTION
FYI: - Im pretty new to rust as a whole. 

As per my comment in the PR, my WASM builds are broken. It seems to be because of Mio.  
I thought I would put up this PR as it might help or not as I need WASM and nannou really needs all your hard work. 

I attempted to pull out tokio for a test but I got stuck as I don't understand enough about how to read rust signatures to fix the removal of futures in read() -  nannou_wgpu/src/texture/image.rs - line 315

Thanks for all you hard work :)